### PR TITLE
Fix to remove old reference

### DIFF
--- a/lib/rollout_ui/engine/app/assets/javascripts/rollout_ui/application.js
+++ b/lib/rollout_ui/engine/app/assets/javascripts/rollout_ui/application.js
@@ -5,5 +5,4 @@
 // the compiled file.
 //
 //= require jquery-ujs
-//= require chosen.jquery
 //= require_tree .


### PR DESCRIPTION
This commit https://github.com/GhostGroup/rollout_ui/commit/e5d1a1fc679307edd3ef787cc836ec1010e52f20 replaced chosen with select, but appears to have missed this file reference.